### PR TITLE
Fix smooth-scroll bug with empty anchors

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,8 +249,10 @@
         // スムーズスクロール
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
+                const href = this.getAttribute('href');
+                if (href === '#') return;
                 e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
+                const target = document.querySelector(href);
                 if (target) {
                     target.scrollIntoView({
                         behavior: 'smooth',


### PR DESCRIPTION
## Summary
- guard the smooth scroll handler from anchors that only reference '#'

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6873c266990c83248810285f8ba7fb55